### PR TITLE
Criação e Listagem de Usuário

### DIFF
--- a/infra/compose.yaml
+++ b/infra/compose.yaml
@@ -1,8 +1,8 @@
 services:
   database:
     container_name: "postgres-dev"
-    image: "postgres:16.0-alpine3.18" # We found this Postgres image on "docker hub"
+    image: "postgres:16.0-alpine3.18" # We can find this Postgres image on "docker hub"
     env_file:
-      - ../.env.development # This makes Postgres from Container & from Outside share the same "variables" ("docker hub"/Postgres image has a list of all needed variables)
+      - ../.env.development # This makes Postgres from Container & from live server share the same "variables" ("docker hub"/Postgres image has a list of all needed variables)
     ports:
       - "5432:5432" # host:container (EXPOSING PORTS TO OUTSIDE THE CONTAINER)

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,4 +1,4 @@
-import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+import { InternalServerError, MethodNotAllowedError, ValidationError } from "infra/errors";
 
 function onNoMatchHandler(request, response) {
   const publicErrorObject = new MethodNotAllowedError();
@@ -6,6 +6,11 @@ function onNoMatchHandler(request, response) {
 }
 
 function onErrorHandler(error, request, response) {
+
+  if (error instanceof ValidationError) {
+    return response.status(error.statusCode).json(error);
+  }
+
   const publicErrorObject = new InternalServerError({
     statusCode: error.statusCode,
     cause: error,

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,4 +1,4 @@
-import { InternalServerError, MethodNotAllowedError, ValidationError } from "infra/errors";
+import { InternalServerError, MethodNotAllowedError, ValidationError, NotFoundError } from "infra/errors";
 
 function onNoMatchHandler(request, response) {
   const publicErrorObject = new MethodNotAllowedError();
@@ -7,7 +7,7 @@ function onNoMatchHandler(request, response) {
 
 function onErrorHandler(error, request, response) {
 
-  if (error instanceof ValidationError) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
     return response.status(error.statusCode).json(error);
   }
 

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,4 +1,9 @@
-import { InternalServerError, MethodNotAllowedError, ValidationError, NotFoundError } from "infra/errors";
+import {
+  InternalServerError,
+  MethodNotAllowedError,
+  ValidationError,
+  NotFoundError,
+} from "infra/errors";
 
 function onNoMatchHandler(request, response) {
   const publicErrorObject = new MethodNotAllowedError();
@@ -6,7 +11,6 @@ function onNoMatchHandler(request, response) {
 }
 
 function onErrorHandler(error, request, response) {
-
   if (error instanceof ValidationError || error instanceof NotFoundError) {
     return response.status(error.statusCode).json(error);
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -83,7 +83,9 @@ export class NotFoundError extends Error {
       cause,
     });
     this.name = "NotFoundError";
-    this.action = action || "Verifique se os parâmetros enviados na consulta estão corretos.";
+    this.action =
+      action ||
+      "Verifique se os parâmetros enviados na consulta estão corretos.";
     this.statusCode = 404;
   }
 

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -76,3 +76,23 @@ export class ValidationError extends Error {
     };
   }
 }
+
+export class NotFoundError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "Não foi possível encontrar este recurso no sistema.", {
+      cause,
+    });
+    this.name = "NotFoundError";
+    this.action = action || "Verifique se os parâmetros enviados na consulta estão corretos.";
+    this.statusCode = 404;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -8,7 +8,7 @@ export class InternalServerError extends Error {
     this.statusCode = statusCode || 500;
   }
 
-  toJson() {
+  toJSON() {
     return {
       name: this.name,
       message: this.message,
@@ -28,7 +28,7 @@ export class ServiceError extends Error {
     this.statusCode = 503;
   }
 
-  toJson() {
+  toJSON() {
     return {
       name: this.name,
       message: this.message,
@@ -45,6 +45,26 @@ export class MethodNotAllowedError extends Error {
     this.action =
       "Verifique se o método HTTP enviado é válido para este endpoint.";
     this.statusCode = 405;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ValidationError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "Um erro de validação ocorreu.", {
+      cause,
+    });
+    this.name = "ValidationError";
+    this.action = action || "Ajuste os dados enviados e tente novamente.";
+    this.statusCode = 400;
   }
 
   toJSON() {

--- a/infra/migrations/1761604939197_test-migration.js
+++ b/infra/migrations/1761604939197_test-migration.js
@@ -1,7 +1,0 @@
-/* eslint-disable no-unused-vars */
-
-exports.shorthands = undefined;
-
-exports.up = (pgm) => {};
-
-exports.down = (pgm) => {};

--- a/infra/migrations/1779574392334_create-users.js
+++ b/infra/migrations/1779574392334_create-users.js
@@ -25,8 +25,8 @@ exports.up = (pgm) => {
       type: "varchar(60)",
       notNull: true,
     },
-    
-    // Why timestamp with timezone? https://justatheory.com/2012/04/postgres-use-timestamptz 
+
+    // Why timestamp with timezone? https://justatheory.com/2012/04/postgres-use-timestamptz
     // timestamptz ~ with "tz" because we wanna have the timezone from where it was created
     createdAt: {
       type: "timestamptz",
@@ -38,9 +38,9 @@ exports.up = (pgm) => {
       notNull: true,
       default: pgm.func("timezone('utc', now())"),
     },
-  })
+  });
 };
 
 // "false" diz para o módulo que não existe o ~movimento~ "down" nessa migration.
 // apenas o que está declarado acima, "up".
-exports.down = false; 
+exports.down = false;

--- a/infra/migrations/1779574392334_create-users.js
+++ b/infra/migrations/1779574392334_create-users.js
@@ -1,0 +1,46 @@
+exports.up = (pgm) => {
+  pgm.createTable("users", {
+    id: {
+      type: "uuid",
+      primaryKey: true,
+      default: pgm.func("gen_random_uuid()"),
+    },
+
+    // For reference Github limits usernames to 39 characters
+    username: {
+      type: "varchar(30)",
+      notNull: true,
+      unique: true,
+    },
+
+    // why 254 in length? https://stackoverflow.com/a/1199238
+    email: {
+      type: "varchar(254)",
+      notNull: true,
+      unique: true,
+    },
+
+    // why 60 in lenght? (search for "Hash Info" on https://www.npmjs.com/package/bcrypt)
+    password: {
+      type: "varchar(60)",
+      notNull: true,
+    },
+    
+    // Why timestamp with timezone? https://justatheory.com/2012/04/postgres-use-timestamptz 
+    // timestamptz ~ with "tz" because we wanna have the timezone from where it was created
+    createdAt: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("timezone('utc', now())"),
+    },
+    updatedAt: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("timezone('utc', now())"),
+    },
+  })
+};
+
+// "false" diz para o módulo que não existe o ~movimento~ "down" nessa migration.
+// apenas o que está declarado acima, "up".
+exports.down = false; 

--- a/models/migrator.js
+++ b/models/migrator.js
@@ -6,7 +6,7 @@ const defaultMifrationsOptions = {
   dryRun: true,
   dir: resolve("infra", "migrations"),
   direction: "up",
-  verbose: true,
+  log: () => {},
   migrationsTable: "pgmigrations",
 };
 

--- a/models/user.js
+++ b/models/user.js
@@ -1,4 +1,4 @@
-import database from "infra/database.js"
+import database from "infra/database.js";
 import { ValidationError, NotFoundError } from "infra/errors.js";
 
 async function findOneByUsername(username) {
@@ -32,7 +32,6 @@ async function findOneByUsername(username) {
 }
 
 async function create(userInputValues) {
-
   await validateUniqueEmail(userInputValues.email);
   await validateUniqueUsername(userInputValues.username);
 
@@ -49,9 +48,7 @@ async function create(userInputValues) {
         WHERE 
           LOWER(username) = LOWER($1)
         ;`,
-      values: [
-        username,
-      ],
+      values: [username],
     });
 
     // rowCount (fornecido pelo Banco de Dados)
@@ -73,9 +70,7 @@ async function create(userInputValues) {
         WHERE 
           LOWER(email) = LOWER($1)
         ;`,
-      values: [
-        email,
-      ],
+      values: [email],
     });
 
     // rowCount (fornecido pelo Banco de Dados)

--- a/models/user.js
+++ b/models/user.js
@@ -1,0 +1,85 @@
+import database from "infra/database.js"
+import { ValidationError } from "infra/errors.js";
+
+async function create(userInputValues) {
+
+  await validateUniqueEmail(userInputValues.email);
+  await validateUniqueUsername(userInputValues.username);
+
+  const newUser = await runInsertQuery(userInputValues);
+  return newUser;
+
+  async function validateUniqueUsername(username) {
+    const results = await database.query({
+      text: `
+        SELECT
+          username 
+        FROM
+          users
+        WHERE 
+          LOWER(username) = LOWER($1)
+        ;`,
+      values: [
+        username,
+      ],
+    });
+
+    // rowCount (fornecido pelo Banco de Dados)
+    if (results.rowCount > 0) {
+      throw new ValidationError({
+        message: "O nome de usuário informado já está sendo utilizado.",
+        action: "Utilize outro nome de usuário para realizar o cadastro.",
+      });
+    }
+  }
+
+  async function validateUniqueEmail(email) {
+    const results = await database.query({
+      text: `
+        SELECT
+          email 
+        FROM
+          users
+        WHERE 
+          LOWER(email) = LOWER($1)
+        ;`,
+      values: [
+        email,
+      ],
+    });
+
+    // rowCount (fornecido pelo Banco de Dados)
+    if (results.rowCount > 0) {
+      throw new ValidationError({
+        message: "O email informado já está sendo utilizado.",
+        action: "Utilize outro email para realizar o cadastro.",
+      });
+    }
+  }
+
+  async function runInsertQuery(userInputValues) {
+    const results = await database.query({
+      text: `
+        INSERT INTO 
+          users (username, email, password) 
+        VALUES 
+          ($1, $2, $3) 
+        RETURNING 
+          *
+        ;`,
+      values: [
+        userInputValues.username,
+        userInputValues.email,
+        userInputValues.password,
+      ],
+    });
+
+    return results.rows[0];
+  }
+}
+
+const user = {
+  create,
+};
+
+export default user;

--- a/models/user.js
+++ b/models/user.js
@@ -1,5 +1,35 @@
 import database from "infra/database.js"
-import { ValidationError } from "infra/errors.js";
+import { ValidationError, NotFoundError } from "infra/errors.js";
+
+async function findOneByUsername(username) {
+  const userFound = await runSelectQuery(username);
+
+  return userFound;
+
+  async function runSelectQuery(username) {
+    const results = await database.query({
+      text: `
+        SELECT
+          * 
+        FROM
+          users
+        WHERE 
+          LOWER(username) = LOWER($1)
+        LIMIT 1
+        ;`,
+      values: [username],
+    });
+
+    if (results.rowCount == 0) {
+      throw new NotFoundError({
+        message: "O usuário informado não foi encontrado no sistema.",
+        action: "Verifique se o username está digitado correctamente.",
+      });
+    }
+
+    return results.rows[0];
+  }
+}
 
 async function create(userInputValues) {
 
@@ -80,6 +110,7 @@ async function create(userInputValues) {
 
 const user = {
   create,
+  findOneByUsername,
 };
 
 export default user;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "pg": "8.16.3",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "swr": "2.2.5"
+        "swr": "2.2.5",
+        "uuid": "11.1.0"
       },
       "devDependencies": {
         "@commitlint/cli": "19.4.0",
@@ -10682,6 +10683,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "pg": "8.16.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "swr": "2.2.5"
+    "swr": "2.2.5",
+    "uuid": "11.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "19.4.0",

--- a/pages/api/v1/users/[username]/index.js
+++ b/pages/api/v1/users/[username]/index.js
@@ -1,6 +1,6 @@
 import { createRouter } from "next-connect";
 import controller from "infra/controller.js";
-import user from "models/user.js"
+import user from "models/user.js";
 
 const router = createRouter();
 

--- a/pages/api/v1/users/[username]/index.js
+++ b/pages/api/v1/users/[username]/index.js
@@ -1,0 +1,17 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controller.js";
+import user from "models/user.js"
+
+const router = createRouter();
+
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(request, response) {
+  // api/v1/users/[username]
+  // api/v1/users/JoaoVictor
+  const username = request.query.username; // "JoaoVictor"
+  const userFound = await user.findOneByUsername(username);
+  return response.status(200).json(userFound);
+}

--- a/pages/api/v1/users/index.js
+++ b/pages/api/v1/users/index.js
@@ -1,6 +1,6 @@
 import { createRouter } from "next-connect";
 import controller from "infra/controller.js";
-import user from "models/user.js"
+import user from "models/user.js";
 
 const router = createRouter();
 

--- a/pages/api/v1/users/index.js
+++ b/pages/api/v1/users/index.js
@@ -1,0 +1,15 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controller.js";
+import user from "models/user.js"
+
+const router = createRouter();
+
+router.post(postHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function postHandler(request, response) {
+  const userInputValues = request.body;
+  const newUser = await user.create(userInputValues);
+  return response.status(201).json(newUser);
+}

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -1,0 +1,102 @@
+import { version as uuidVersion } from 'uuid';
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("GET /api/v1/users/[username]", () => {
+  describe("Anonymous user", () => {
+      test("With exact case match", async () => {
+        const response1 = await fetch("http://localhost:3000/api/v1/users",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              username: "MesmoCase",
+              email: "mesmo.case@curso.dev",
+              password: "senha123",
+            }),
+          },
+        );
+
+        expect(response1.status).toBe(201);
+
+        const response2 = await fetch("http://localhost:3000/api/v1/users/MesmoCase");
+
+        expect(response2.status).toBe(200);
+
+        const response2Body = await response2.json();
+
+        expect(response2Body).toEqual({
+          id: response2Body.id,
+          username: 'MesmoCase',
+          email: 'mesmo.case@curso.dev',
+          password: 'senha123',
+          createdAt: response2Body.createdAt,
+          updatedAt: response2Body.updatedAt,
+        });
+
+        expect(uuidVersion(response2Body.id)).toBe(4);
+        expect(Date.parse(response2Body.createdAt)).not.toBeNaN()
+        expect(Date.parse(response2Body.updatedAt)).not.toBeNaN()
+      });
+
+      test("With case mismatch", async () => {
+        const response1 = await fetch("http://localhost:3000/api/v1/users",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              username: "CaseDiferente",
+              email: "case.diferente@curso.dev",
+              password: "senha123",
+            }),
+          },
+        );
+
+        expect(response1.status).toBe(201);
+
+        const response2 = await fetch("http://localhost:3000/api/v1/users/casediferente");
+
+        expect(response2.status).toBe(200);
+
+        const response2Body = await response2.json();
+
+        expect(response2Body).toEqual({
+          id: response2Body.id,
+          username: 'CaseDiferente',
+          email: 'case.diferente@curso.dev',
+          password: 'senha123',
+          createdAt: response2Body.createdAt,
+          updatedAt: response2Body.updatedAt,
+        });
+
+        expect(uuidVersion(response2Body.id)).toBe(4);
+        expect(Date.parse(response2Body.createdAt)).not.toBeNaN()
+        expect(Date.parse(response2Body.updatedAt)).not.toBeNaN()
+      });
+
+      test("With nonexistent username", async () => {
+        const response = await fetch("http://localhost:3000/api/v1/users/UsuarioInexistente");
+
+        // Not Found
+        expect(response.status).toBe(404);
+
+        const responseBody = await response.json();
+
+        expect(responseBody).toEqual({
+          name: "NotFoundError",
+          message: "O usuário informado não foi encontrado no sistema.",
+          action: "Verifique se o username está digitado correctamente.",
+          status_code: 404,
+        });
+      });
+  });
+});

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -1,4 +1,4 @@
-import { version as uuidVersion } from 'uuid';
+import { version as uuidVersion } from "uuid";
 import orchestrator from "tests/orchestrator.js";
 
 beforeAll(async () => {
@@ -9,94 +9,96 @@ beforeAll(async () => {
 
 describe("GET /api/v1/users/[username]", () => {
   describe("Anonymous user", () => {
-      test("With exact case match", async () => {
-        const response1 = await fetch("http://localhost:3000/api/v1/users",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              username: "MesmoCase",
-              email: "mesmo.case@curso.dev",
-              password: "senha123",
-            }),
-          },
-        );
-
-        expect(response1.status).toBe(201);
-
-        const response2 = await fetch("http://localhost:3000/api/v1/users/MesmoCase");
-
-        expect(response2.status).toBe(200);
-
-        const response2Body = await response2.json();
-
-        expect(response2Body).toEqual({
-          id: response2Body.id,
-          username: 'MesmoCase',
-          email: 'mesmo.case@curso.dev',
-          password: 'senha123',
-          createdAt: response2Body.createdAt,
-          updatedAt: response2Body.updatedAt,
-        });
-
-        expect(uuidVersion(response2Body.id)).toBe(4);
-        expect(Date.parse(response2Body.createdAt)).not.toBeNaN()
-        expect(Date.parse(response2Body.updatedAt)).not.toBeNaN()
+    test("With exact case match", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "MesmoCase",
+          email: "mesmo.case@curso.dev",
+          password: "senha123",
+        }),
       });
 
-      test("With case mismatch", async () => {
-        const response1 = await fetch("http://localhost:3000/api/v1/users",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              username: "CaseDiferente",
-              email: "case.diferente@curso.dev",
-              password: "senha123",
-            }),
-          },
-        );
+      expect(response1.status).toBe(201);
 
-        expect(response1.status).toBe(201);
+      const response2 = await fetch(
+        "http://localhost:3000/api/v1/users/MesmoCase",
+      );
 
-        const response2 = await fetch("http://localhost:3000/api/v1/users/casediferente");
+      expect(response2.status).toBe(200);
 
-        expect(response2.status).toBe(200);
+      const response2Body = await response2.json();
 
-        const response2Body = await response2.json();
-
-        expect(response2Body).toEqual({
-          id: response2Body.id,
-          username: 'CaseDiferente',
-          email: 'case.diferente@curso.dev',
-          password: 'senha123',
-          createdAt: response2Body.createdAt,
-          updatedAt: response2Body.updatedAt,
-        });
-
-        expect(uuidVersion(response2Body.id)).toBe(4);
-        expect(Date.parse(response2Body.createdAt)).not.toBeNaN()
-        expect(Date.parse(response2Body.updatedAt)).not.toBeNaN()
+      expect(response2Body).toEqual({
+        id: response2Body.id,
+        username: "MesmoCase",
+        email: "mesmo.case@curso.dev",
+        password: "senha123",
+        createdAt: response2Body.createdAt,
+        updatedAt: response2Body.updatedAt,
       });
 
-      test("With nonexistent username", async () => {
-        const response = await fetch("http://localhost:3000/api/v1/users/UsuarioInexistente");
+      expect(uuidVersion(response2Body.id)).toBe(4);
+      expect(Date.parse(response2Body.createdAt)).not.toBeNaN();
+      expect(Date.parse(response2Body.updatedAt)).not.toBeNaN();
+    });
 
-        // Not Found
-        expect(response.status).toBe(404);
-
-        const responseBody = await response.json();
-
-        expect(responseBody).toEqual({
-          name: "NotFoundError",
-          message: "O usuário informado não foi encontrado no sistema.",
-          action: "Verifique se o username está digitado correctamente.",
-          status_code: 404,
-        });
+    test("With case mismatch", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "CaseDiferente",
+          email: "case.diferente@curso.dev",
+          password: "senha123",
+        }),
       });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch(
+        "http://localhost:3000/api/v1/users/casediferente",
+      );
+
+      expect(response2.status).toBe(200);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        id: response2Body.id,
+        username: "CaseDiferente",
+        email: "case.diferente@curso.dev",
+        password: "senha123",
+        createdAt: response2Body.createdAt,
+        updatedAt: response2Body.updatedAt,
+      });
+
+      expect(uuidVersion(response2Body.id)).toBe(4);
+      expect(Date.parse(response2Body.createdAt)).not.toBeNaN();
+      expect(Date.parse(response2Body.updatedAt)).not.toBeNaN();
+    });
+
+    test("With nonexistent username", async () => {
+      const response = await fetch(
+        "http://localhost:3000/api/v1/users/UsuarioInexistente",
+      );
+
+      // Not Found
+      expect(response.status).toBe(404);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "NotFoundError",
+        message: "O usuário informado não foi encontrado no sistema.",
+        action: "Verifique se o username está digitado correctamente.",
+        status_code: 404,
+      });
+    });
   });
 });

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -1,0 +1,140 @@
+import { version as uuidVersion } from 'uuid';
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("POST /api/v1/users", () => {
+  describe("Anonymous user", () => {
+      test("With unique and valid data", async () => {
+        const response = await fetch(
+          "http://localhost:3000/api/v1/users",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              username: "joaovictor",
+              email: "joao@curso.dev",
+              password: "senha123",
+            }),
+          },
+        );
+
+        expect(response.status).toBe(201);
+
+        const responseBody = await response.json();
+
+        expect(responseBody).toEqual({
+          id: responseBody.id,
+          username: 'joaovictor',
+          email: 'joao@curso.dev',
+          password: 'senha123',
+          createdAt: responseBody.createdAt,
+          updatedAt: responseBody.updatedAt,
+        });
+
+        expect(uuidVersion(responseBody.id)).toBe(4);
+        expect(Date.parse(responseBody.createdAt)).not.toBeNaN()
+        expect(Date.parse(responseBody.updatedAt)).not.toBeNaN()
+      });
+
+      test("With duplicated 'email'", async () => {
+        const response1 = await fetch(
+          "http://localhost:3000/api/v1/users",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              username: "emailduplicado1",
+              email: "duplicado@curso.dev",
+              password: "senha123",
+            }),
+          },
+        );
+
+        expect(response1.status).toBe(201);
+
+        const response2 = await fetch(
+          "http://localhost:3000/api/v1/users",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              username: "emailduplicado2",
+              email: "Duplicado@curso.dev",
+              password: "senha123",
+            }),
+          },
+        );
+
+        // Bad Request
+        expect(response2.status).toBe(400);
+        
+        const response2Body = await response2.json();
+        console.log(response2Body);
+
+        expect(response2Body).toEqual({
+          name: "ValidationError",
+          message: "O email informado já está sendo utilizado.",
+          action: "Utilize outro email para realizar o cadastro.",
+          status_code: 400,
+        })
+      });
+
+
+      test("With duplicated 'username'", async () => {
+        const response1 = await fetch(
+          "http://localhost:3000/api/v1/users",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              username: "usernameduplicado",
+              email: "username1@curso.dev",
+              password: "senha123",
+            }),
+          },
+        );
+
+        expect(response1.status).toBe(201);
+
+        const response2 = await fetch(
+          "http://localhost:3000/api/v1/users",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              username: "UsernameDuplicado",
+              email: "username2@curso.dev",
+              password: "senha123",
+            }),
+          },
+        );
+
+        // Bad Request
+        expect(response2.status).toBe(400);
+        
+        const response2Body = await response2.json();
+
+        expect(response2Body).toEqual({
+          name: "ValidationError",
+          message: "O nome de usuário informado já está sendo utilizado.",
+          action: "Utilize outro nome de usuário para realizar o cadastro.",
+          status_code: 400,
+        })
+      });
+  });
+});

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -1,4 +1,4 @@
-import { version as uuidVersion } from 'uuid';
+import { version as uuidVersion } from "uuid";
 import orchestrator from "tests/orchestrator.js";
 
 beforeAll(async () => {
@@ -9,130 +9,115 @@ beforeAll(async () => {
 
 describe("POST /api/v1/users", () => {
   describe("Anonymous user", () => {
-      test("With unique and valid data", async () => {
-        const response = await fetch(
-          "http://localhost:3000/api/v1/users",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              username: "joaovictor",
-              email: "joao@curso.dev",
-              password: "senha123",
-            }),
-          },
-        );
-
-        expect(response.status).toBe(201);
-
-        const responseBody = await response.json();
-
-        expect(responseBody).toEqual({
-          id: responseBody.id,
-          username: 'joaovictor',
-          email: 'joao@curso.dev',
-          password: 'senha123',
-          createdAt: responseBody.createdAt,
-          updatedAt: responseBody.updatedAt,
-        });
-
-        expect(uuidVersion(responseBody.id)).toBe(4);
-        expect(Date.parse(responseBody.createdAt)).not.toBeNaN()
-        expect(Date.parse(responseBody.updatedAt)).not.toBeNaN()
+    test("With unique and valid data", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "joaovictor",
+          email: "joao@curso.dev",
+          password: "senha123",
+        }),
       });
 
-      test("With duplicated 'email'", async () => {
-        const response1 = await fetch(
-          "http://localhost:3000/api/v1/users",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              username: "emailduplicado1",
-              email: "duplicado@curso.dev",
-              password: "senha123",
-            }),
-          },
-        );
+      expect(response.status).toBe(201);
 
-        expect(response1.status).toBe(201);
+      const responseBody = await response.json();
 
-        const response2 = await fetch(
-          "http://localhost:3000/api/v1/users",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              username: "emailduplicado2",
-              email: "Duplicado@curso.dev",
-              password: "senha123",
-            }),
-          },
-        );
-
-        // Bad Request
-        expect(response2.status).toBe(400);
-        
-        const response2Body = await response2.json();
-
-        expect(response2Body).toEqual({
-          name: "ValidationError",
-          message: "O email informado já está sendo utilizado.",
-          action: "Utilize outro email para realizar o cadastro.",
-          status_code: 400,
-        })
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        username: "joaovictor",
+        email: "joao@curso.dev",
+        password: "senha123",
+        createdAt: responseBody.createdAt,
+        updatedAt: responseBody.updatedAt,
       });
 
-      test("With duplicated 'username'", async () => {
-        const response1 = await fetch(
-          "http://localhost:3000/api/v1/users",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              username: "usernameduplicado",
-              email: "username1@curso.dev",
-              password: "senha123",
-            }),
-          },
-        );
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.createdAt)).not.toBeNaN();
+      expect(Date.parse(responseBody.updatedAt)).not.toBeNaN();
+    });
 
-        expect(response1.status).toBe(201);
-
-        const response2 = await fetch(
-          "http://localhost:3000/api/v1/users",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              username: "UsernameDuplicado",
-              email: "username2@curso.dev",
-              password: "senha123",
-            }),
-          },
-        );
-
-        // Bad Request
-        expect(response2.status).toBe(400);
-        
-        const response2Body = await response2.json();
-
-        expect(response2Body).toEqual({
-          name: "ValidationError",
-          message: "O nome de usuário informado já está sendo utilizado.",
-          action: "Utilize outro nome de usuário para realizar o cadastro.",
-          status_code: 400,
-        })
+    test("With duplicated 'email'", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "emailduplicado1",
+          email: "duplicado@curso.dev",
+          password: "senha123",
+        }),
       });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "emailduplicado2",
+          email: "Duplicado@curso.dev",
+          password: "senha123",
+        }),
+      });
+
+      // Bad Request
+      expect(response2.status).toBe(400);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        name: "ValidationError",
+        message: "O email informado já está sendo utilizado.",
+        action: "Utilize outro email para realizar o cadastro.",
+        status_code: 400,
+      });
+    });
+
+    test("With duplicated 'username'", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "usernameduplicado",
+          email: "username1@curso.dev",
+          password: "senha123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "UsernameDuplicado",
+          email: "username2@curso.dev",
+          password: "senha123",
+        }),
+      });
+
+      // Bad Request
+      expect(response2.status).toBe(400);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        name: "ValidationError",
+        message: "O nome de usuário informado já está sendo utilizado.",
+        action: "Utilize outro nome de usuário para realizar o cadastro.",
+        status_code: 400,
+      });
+    });
   });
 });

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -80,7 +80,6 @@ describe("POST /api/v1/users", () => {
         expect(response2.status).toBe(400);
         
         const response2Body = await response2.json();
-        console.log(response2Body);
 
         expect(response2Body).toEqual({
           name: "ValidationError",
@@ -89,7 +88,6 @@ describe("POST /api/v1/users", () => {
           status_code: 400,
         })
       });
-
 
       test("With duplicated 'username'", async () => {
         const response1 = await fetch(

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,5 +1,6 @@
 import retry from "async-retry";
-import database from "infra/database";
+import database from "infra/database.js";
+import migrator from "models/migrator.js";
 
 async function waitForAllServices() {
   await waitForWebServer();
@@ -27,9 +28,14 @@ async function clearDatabase() {
   await database.query("drop schema public cascade; create schema public;");
 }
 
+async function runPendingMigrations() {
+  await migrator.runPendingMigrations();
+}
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
+  runPendingMigrations,
 };
 
 export default orchestrator;


### PR DESCRIPTION
- Cria model `user`
- Cria 2 novos endpoints:
            - `POST` `/api/v1/users`
            - `GET` `api/v1/users/[username]`
- Remove `migration` de test
- Cria `migration` responsável por criar a tabela `users`
- Cria dois novos erros customizados:
            - `ValidationError`
            - `NotFoundError`
- Adiciona novo método ao `orchestrator`:
            - `runPendingMigrations`
- Silencia os logs do `migrator`